### PR TITLE
add popLogs() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,5 +32,13 @@ DebugLogtron.prototype.unwhitelist = function unwhitelist(level, msg) {
 };
 
 DebugLogtron.prototype.items = function items() {
-    return this._backend.records;
+    return this._backend.items();
+};
+
+DebugLogtron.prototype.popLogs = function popLogs(message) {
+    return this._backend.popLogs(message);
+};
+
+DebugLogtron.prototype.isEmpty = function isEmpty() {
+    return this._backend.isEmpty();
 };


### PR DESCRIPTION
I've added a new `popLogs()` method. The idea is that
you can now get out just the log lines for a single
[level, msg] tuple.

You can then loop over the list and do homogenous 
assertions on those logs.

I've also added a useful `.isEmpty()` method that you
can assert against to fail the test if you there
were other logs that you either:
- did not whitelist
- did not pop out of the logger.

r: @rf @jcorbin
