### PR TITLE
Add 'unwhitelist' and make 'npm test' pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ testing easier
 ```
 var DebugLogtron = require('debug-logtron');
 var test = require('tape');
- 
+
 test('some module', function t(assert) {
     var logger = NullLogtron('mything');
     var thing = new Thing({ logger: logger })
- 
+
     logger.whitelist('error', 'some msg');
 
     thing.doStuff();
- 
+
     var items = logger.items();
     assert.equal(items.filter(function (x) {
         return x.levelName === 'error'
@@ -56,6 +56,10 @@ test('some module', function t(assert) {
     assert.end();
 });
 ```
+
+Whilst it is recommended that you minimize state between tests by creating
+a new instance of debug-logtron, it is possible to remove a whitelisted item
+by calling `.unwhitelist` with the same arguments.
 
 ## Interface
 
@@ -74,7 +78,7 @@ If you want to see trace() logs you must set `NODE_DEBUG=mylibrary TRACE=1`
 
 **Warning:** This a logger for testing! Not a default logger.
 
-If you want to add a default logger to your `dependencies` 
+If you want to add a default logger to your `dependencies`
   then I strongly recommend you use [`null-logtron`][null-logtron]
 
 ## Motivation

--- a/backends/debug-log-backend.js
+++ b/backends/debug-log-backend.js
@@ -93,7 +93,7 @@ DebugLogBackend.prototype.unwhitelist = function unwhitelist(level, msg) {
     var self = this;
 
     self.whitelists[level][msg] = false;
-}
+};
 
 DebugLogBackend.prototype.createStream = function createStream() {
     var self = this;

--- a/backends/debug-log-backend.js
+++ b/backends/debug-log-backend.js
@@ -123,6 +123,7 @@ DebugLogStream.prototype.write = function write(logMessage, cb) {
     if (whitelist[logRecord.msg]) {
         self.backend.records.push(logRecord);
 
+        /* istanbul ignore else */
         if (cb) {
             cb();
         }
@@ -149,6 +150,7 @@ DebugLogStream.prototype.write = function write(logMessage, cb) {
         throw new Error(logRecord.msg);
     }
 
+    /* istanbul ignore else */
     if (cb) {
         cb();
     }

--- a/backends/debug-log-backend.js
+++ b/backends/debug-log-backend.js
@@ -30,7 +30,7 @@ var COLOR_MAP = {
 module.exports = DebugLogBackend;
 
 function DebugLogBackend(namespace, opts) {
-    /*eslint max-statements: [2, 25]*/
+    /* eslint max-statements: [2, 25] */
     if (!(this instanceof DebugLogBackend)) {
         return new DebugLogBackend(namespace, opts);
     }
@@ -88,6 +88,12 @@ DebugLogBackend.prototype.whitelist = function whitelist(level, msg) {
 
     self.whitelists[level][msg] = true;
 };
+
+DebugLogBackend.prototype.unwhitelist = function unwhitelist(level, msg) {
+    var self = this;
+
+    self.whitelists[level][msg] = false;
+}
 
 DebugLogBackend.prototype.createStream = function createStream() {
     var self = this;

--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ DebugLogtron.prototype.whitelist = function whitelist(level, msg) {
     this._backend.whitelist(level, msg);
 };
 
+DebugLogtron.prototype.unwhitelist = function unwhitelist(level, msg) {
+    this._backend.unwhitelist(level, msg);
+};
+
 DebugLogtron.prototype.items = function items() {
     return this._backend.records;
 };

--- a/lib/base-logtron.js
+++ b/lib/base-logtron.js
@@ -9,6 +9,7 @@ var LEVELS = require('./levels.js').LEVELS_BY_NAME;
 module.exports = BaseLogtron;
 
 function BaseLogtron(opts) {
+    /* istanbul ignore next */
     if (!(this instanceof BaseLogtron)) {
         return new BaseLogtron(opts);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -402,6 +402,29 @@ test('can whitelist errors', function t(assert) {
     });
 });
 
+test('can unwhitelist errors', function t(assert) {
+    var logger = allocLogger();
+
+    assert.throws(function throwIt() {
+        logger.error('oh hi');
+    }, /oh hi/);
+
+    logger.whitelist('error', 'oh hi');
+
+    logger.error('oh hi');
+
+    assert.equal(logger.items().length, 1);
+    assert.equal(logger.items()[0].msg, 'oh hi');
+
+    logger.unwhitelist('error', 'oh hi');
+
+    assert.throws(function throwIt() {
+        logger.error('oh hi');
+    }, /oh hi/);
+
+    assert.end();
+});
+
 function allocLogger(opts) {
     opts = opts || {};
     var logger = DebugLogtron('debuglogtrontestcode', {


### PR DESCRIPTION
@Raynos 

Not ideal, but useful for some cases where logger state is shared across tests.
