### PR TITLE
add writeEntry method for Logtron compat interface

### DIFF
--- a/lib/base-logtron.js
+++ b/lib/base-logtron.js
@@ -31,6 +31,24 @@ BaseLogtron.prototype._log = function _log(level, msg, meta, cb) {
     }
 };
 
+// Logtron compatible writeEntry, assumes `entry` is a `logtron/entry`
+BaseLogtron.prototype.writeEntry = function writeEntry(entry, cb) {
+    var logMessage = new LogMessage(
+        LEVELS[entry.level], 
+        entry.message, 
+        entry.meta, 
+        entry.path
+    );
+
+    LogMessage.isValid(logMessage);
+
+    collectParallel(this._streams, writeMessage, cb || noop);
+
+    function writeMessage(stream, i, callback) {
+        stream.write(logMessage, callback);
+    }
+};
+
 BaseLogtron.prototype.trace = function trace(msg, meta, cb) {
     this._log(LEVELS.trace, msg, meta, cb);
 };


### PR DESCRIPTION
Added `writeEntry` to make `DebugLogtron` more closely follow the `Logtron` interface

@Raynos 
